### PR TITLE
LPD-86099 Use service-layer finder instead of DynamicQuery

### DIFF
--- a/modules/apps/announcements/announcements-web-test/bnd.bnd
+++ b/modules/apps/announcements/announcements-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Announcements Web Test
+Bundle-SymbolicName: com.liferay.announcements.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/announcements/announcements-web-test/build.gradle
+++ b/modules/apps/announcements/announcements-web-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationImplementation group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testIntegrationImplementation project(":apps:announcements:announcements-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/announcements/announcements-web-test/src/testIntegration/java/com/liferay/announcements/web/internal/display/context/test/AnnouncementsAdminViewDisplayContextTest.java
+++ b/modules/apps/announcements/announcements-web-test/src/testIntegration/java/com/liferay/announcements/web/internal/display/context/test/AnnouncementsAdminViewDisplayContextTest.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.announcements.web.internal.display.context.test;
+
+import com.liferay.announcements.kernel.exception.EntryDisplayDateException;
+import com.liferay.announcements.kernel.exception.EntryExpirationDateException;
+import com.liferay.announcements.kernel.model.AnnouncementsEntry;
+import com.liferay.announcements.kernel.service.AnnouncementsEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.portlet.RenderRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.lang.reflect.Constructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Akhash R
+ */
+@RunWith(Arquillian.class)
+public class AnnouncementsAdminViewDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(
+			AnnouncementsAdminViewDisplayContextTest.class);
+
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.announcements.web");
+
+		Class<?> clazz = bundle.loadClass(
+			"com.liferay.announcements.web.internal.display.context." +
+				"AnnouncementsAdminViewDisplayContext");
+
+		_constructor = clazz.getConstructor(
+			HttpServletRequest.class, LiferayPortletRequest.class,
+			LiferayPortletResponse.class, RenderRequest.class);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_user = UserTestUtil.getAdminUser(TestPropsValues.getCompanyId());
+	}
+
+	@Test
+	public void testGetSearchContainer() throws Exception {
+		int count =
+			_announcementsEntryLocalService.getAnnouncementsEntriesCount();
+
+		_addEntry("Beta");
+		_addEntry("Alpha");
+		_addEntry("Charlie");
+
+		ThemeDisplay themeDisplay = _getThemeDisplay();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+		mockHttpServletRequest.setParameter("orderByCol", "title");
+		mockHttpServletRequest.setParameter("orderByType", "asc");
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest(mockHttpServletRequest);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+		mockLiferayPortletRenderRequest.setAttribute(
+			StringBundler.concat(
+				mockLiferayPortletRenderRequest.getPortletName(), "-",
+				WebKeys.CURRENT_PORTLET_URL),
+			new MockLiferayPortletURL());
+		mockLiferayPortletRenderRequest.setParameter("orderByCol", "title");
+		mockLiferayPortletRenderRequest.setParameter("orderByType", "asc");
+
+		Object announcementsAdminViewDisplayContext = _constructor.newInstance(
+			mockHttpServletRequest, mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse(),
+			mockLiferayPortletRenderRequest);
+
+		SearchContainer<AnnouncementsEntry> searchContainer =
+			ReflectionTestUtil.invoke(
+				announcementsAdminViewDisplayContext, "getSearchContainer",
+				new Class<?>[0]);
+
+		List<AnnouncementsEntry> results = searchContainer.getResults();
+
+		Assert.assertEquals(results.toString(), count + 3, results.size());
+
+		Assert.assertEquals(
+			"Alpha",
+			results.get(
+				0
+			).getTitle());
+		Assert.assertEquals(
+			"Beta",
+			results.get(
+				1
+			).getTitle());
+		Assert.assertEquals(
+			"Charlie",
+			results.get(
+				2
+			).getTitle());
+	}
+
+	private void _addEntry(String title) throws Exception {
+		AnnouncementsEntry entry = _announcementsEntryLocalService.addEntry(
+			_user.getUserId(), 0, 0, title, "content", "http://localhost",
+			"general",
+			_portal.getDate(
+				1, 1, 1990, 1, 1, _user.getTimeZone(),
+				EntryDisplayDateException.class),
+			_portal.getDate(
+				1, 1, 3000, 1, 1, _user.getTimeZone(),
+				EntryExpirationDateException.class),
+			1, false);
+
+		_announcementsEntries.add(entry);
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_user.getCompanyId()));
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private static Constructor<?> _constructor;
+
+	@DeleteAfterTestRun
+	private final List<AnnouncementsEntry> _announcementsEntries =
+		new ArrayList<>();
+
+	@Inject
+	private AnnouncementsEntryLocalService _announcementsEntryLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private Portal _portal;
+
+	private User _user;
+
+}

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewDisplayContext.java
@@ -11,6 +11,8 @@ import com.liferay.announcements.web.internal.search.AnnouncementsEntryChecker;
 import com.liferay.announcements.web.internal.util.AnnouncementsUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -25,6 +27,8 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -185,6 +189,14 @@ public class AnnouncementsAdminViewDisplayContext {
 
 		announcementsEntriesSearchContainer.setId(getSearchContainerId());
 
+		String orderByCol = ParamUtil.getString(
+			_httpServletRequest, "orderByCol", "modified-date");
+		String orderByType = ParamUtil.getString(
+			_httpServletRequest, "orderByType", "desc");
+
+		announcementsEntriesSearchContainer.setOrderByCol(orderByCol);
+		announcementsEntriesSearchContainer.setOrderByType(orderByType);
+
 		long classNameId = 0;
 		long classPK = 0;
 
@@ -200,15 +212,15 @@ public class AnnouncementsAdminViewDisplayContext {
 		long announcementsClassPK = classPK;
 
 		announcementsEntriesSearchContainer.setResultsAndTotal(
-			() -> AnnouncementsEntryLocalServiceUtil.getEntries(
-				_themeDisplay.getCompanyId(), announcementsClassNameId,
-				announcementsClassPK, Objects.equals(getNavigation(), "alerts"),
+			() -> AnnouncementsEntryLocalServiceUtil.dynamicQuery(
+				_getDynamicQuery(
+					announcementsClassNameId, announcementsClassPK),
 				announcementsEntriesSearchContainer.getStart(),
-				announcementsEntriesSearchContainer.getEnd()),
-			AnnouncementsEntryLocalServiceUtil.getEntriesCount(
-				_themeDisplay.getCompanyId(), announcementsClassNameId,
-				announcementsClassPK,
-				Objects.equals(getNavigation(), "alerts")));
+				announcementsEntriesSearchContainer.getEnd(),
+				_getOrderByComparator(orderByCol, orderByType)),
+			(int)AnnouncementsEntryLocalServiceUtil.dynamicQueryCount(
+				_getDynamicQuery(
+					announcementsClassNameId, announcementsClassPK)));
 
 		announcementsEntriesSearchContainer.setRowChecker(
 			new AnnouncementsEntryChecker(
@@ -227,6 +239,45 @@ public class AnnouncementsAdminViewDisplayContext {
 
 	public UUID getUuid() {
 		return _UUID;
+	}
+
+	private DynamicQuery _getDynamicQuery(long classNameId, long classPK) {
+		DynamicQuery dynamicQuery =
+			AnnouncementsEntryLocalServiceUtil.dynamicQuery();
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"companyId", _themeDisplay.getCompanyId()));
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq("classNameId", classNameId));
+		dynamicQuery.add(RestrictionsFactoryUtil.eq("classPK", classPK));
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.eq(
+				"alert", Objects.equals(getNavigation(), "alerts")));
+
+		return dynamicQuery;
+	}
+
+	private OrderByComparator<AnnouncementsEntry> _getOrderByComparator(
+		String orderByCol, String orderByType) {
+
+		String columnName = "modifiedDate";
+
+		if (orderByCol.equals("display-date")) {
+			columnName = "displayDate";
+		}
+		else if (orderByCol.equals("expiration-date")) {
+			columnName = "expirationDate";
+		}
+		else if (orderByCol.equals("title")) {
+			columnName = "title";
+		}
+		else if (orderByCol.equals("type")) {
+			columnName = "type";
+		}
+
+		return OrderByComparatorFactoryUtil.create(
+			"AnnouncementsEntry", columnName, orderByType.equals("asc"));
 	}
 
 	private static final UUID _UUID = UUID.fromString(

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewDisplayContext.java
@@ -11,8 +11,6 @@ import com.liferay.announcements.web.internal.search.AnnouncementsEntryChecker;
 import com.liferay.announcements.web.internal.util.AnnouncementsUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
-import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -211,16 +209,18 @@ public class AnnouncementsAdminViewDisplayContext {
 		long announcementsClassNameId = classNameId;
 		long announcementsClassPK = classPK;
 
+		boolean alert = Objects.equals(getNavigation(), "alerts");
+
 		announcementsEntriesSearchContainer.setResultsAndTotal(
-			() -> AnnouncementsEntryLocalServiceUtil.dynamicQuery(
-				_getDynamicQuery(
-					announcementsClassNameId, announcementsClassPK),
+			() -> AnnouncementsEntryLocalServiceUtil.getEntries(
+				_themeDisplay.getCompanyId(), announcementsClassNameId,
+				announcementsClassPK, alert,
 				announcementsEntriesSearchContainer.getStart(),
 				announcementsEntriesSearchContainer.getEnd(),
 				_getOrderByComparator(orderByCol, orderByType)),
-			(int)AnnouncementsEntryLocalServiceUtil.dynamicQueryCount(
-				_getDynamicQuery(
-					announcementsClassNameId, announcementsClassPK)));
+			AnnouncementsEntryLocalServiceUtil.getEntriesCount(
+				_themeDisplay.getCompanyId(), announcementsClassNameId,
+				announcementsClassPK, alert));
 
 		announcementsEntriesSearchContainer.setRowChecker(
 			new AnnouncementsEntryChecker(
@@ -239,23 +239,6 @@ public class AnnouncementsAdminViewDisplayContext {
 
 	public UUID getUuid() {
 		return _UUID;
-	}
-
-	private DynamicQuery _getDynamicQuery(long classNameId, long classPK) {
-		DynamicQuery dynamicQuery =
-			AnnouncementsEntryLocalServiceUtil.dynamicQuery();
-
-		dynamicQuery.add(
-			RestrictionsFactoryUtil.eq(
-				"companyId", _themeDisplay.getCompanyId()));
-		dynamicQuery.add(
-			RestrictionsFactoryUtil.eq("classNameId", classNameId));
-		dynamicQuery.add(RestrictionsFactoryUtil.eq("classPK", classPK));
-		dynamicQuery.add(
-			RestrictionsFactoryUtil.eq(
-				"alert", Objects.equals(getNavigation(), "alerts")));
-
-		return dynamicQuery;
 	}
 
 	private OrderByComparator<AnnouncementsEntry> _getOrderByComparator(

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewManagementToolbarDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsAdminViewManagementToolbarDisplayContext.java
@@ -167,6 +167,13 @@ public class AnnouncementsAdminViewManagementToolbarDisplayContext
 		return false;
 	}
 
+	@Override
+	protected String[] getOrderByKeys() {
+		return new String[] {
+			"display-date", "modified-date", "expiration-date", "title", "type"
+		};
+	}
+
 	private List<DropdownItem> _getFilterNavigationDropdownItems()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/announcements/service/impl/AnnouncementsEntryLocalServiceImpl.java
@@ -254,8 +254,19 @@ public class AnnouncementsEntryLocalServiceImpl
 		long companyId, long classNameId, long classPK, boolean alert,
 		int start, int end) {
 
+		return getEntries(
+			companyId, classNameId, classPK, alert, start, end, null);
+	}
+
+	@Override
+	public List<AnnouncementsEntry> getEntries(
+		long companyId, long classNameId, long classPK, boolean alert,
+		int start, int end,
+		OrderByComparator<AnnouncementsEntry> orderByComparator) {
+
 		return announcementsEntryPersistence.findByC_C_C_A(
-			companyId, classNameId, classPK, alert, start, end);
+			companyId, classNameId, classPK, alert, start, end,
+			orderByComparator);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalService.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalService.java
@@ -316,6 +316,12 @@ public interface AnnouncementsEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AnnouncementsEntry> getEntries(
+		long companyId, long classNameId, long classPK, boolean alert,
+		int start, int end,
+		OrderByComparator<AnnouncementsEntry> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AnnouncementsEntry> getEntries(
 		long userId, long classNameId, long[] classPKs, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
 		int displayDateMinute, int expirationDateMonth, int expirationDateDay,
@@ -420,4 +426,4 @@ public interface AnnouncementsEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-519188019
+// LIFERAY-SERVICE-BUILDER-HASH:118272091

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalServiceUtil.java
@@ -360,6 +360,16 @@ public class AnnouncementsEntryLocalServiceUtil {
 	}
 
 	public static List<AnnouncementsEntry> getEntries(
+		long companyId, long classNameId, long classPK, boolean alert,
+		int start, int end,
+		OrderByComparator<AnnouncementsEntry> orderByComparator) {
+
+		return getService().getEntries(
+			companyId, classNameId, classPK, alert, start, end,
+			orderByComparator);
+	}
+
+	public static List<AnnouncementsEntry> getEntries(
 		long userId, long classNameId, long[] classPKs, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
 		int displayDateMinute, int expirationDateMonth, int expirationDateDay,
@@ -512,4 +522,4 @@ public class AnnouncementsEntryLocalServiceUtil {
 	private static volatile AnnouncementsEntryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1296821060
+// LIFERAY-SERVICE-BUILDER-HASH:306442597

--- a/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/announcements/kernel/service/AnnouncementsEntryLocalServiceWrapper.java
@@ -409,6 +409,18 @@ public class AnnouncementsEntryLocalServiceWrapper
 
 	@Override
 	public java.util.List<AnnouncementsEntry> getEntries(
+		long companyId, long classNameId, long classPK, boolean alert,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AnnouncementsEntry>
+			orderByComparator) {
+
+		return _announcementsEntryLocalService.getEntries(
+			companyId, classNameId, classPK, alert, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public java.util.List<AnnouncementsEntry> getEntries(
 		long userId, long classNameId, long[] classPKs, int displayDateMonth,
 		int displayDateDay, int displayDateYear, int displayDateHour,
 		int displayDateMinute, int expirationDateMonth, int expirationDateDay,
@@ -609,4 +621,4 @@ public class AnnouncementsEntryLocalServiceWrapper
 	private AnnouncementsEntryLocalService _announcementsEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:674929502
+// LIFERAY-SERVICE-BUILDER-HASH:913899043


### PR DESCRIPTION
Hi @ak-ragnor — small refactor suggestion on top of your LPD-86099 branch.

The current implementation builds an ad-hoc `DynamicQuery` in `AnnouncementsAdminViewDisplayContext` to sort results, because the existing `AnnouncementsEntryLocalService.getEntries(companyId, classNameId, classPK, alert, start, end)` doesn't accept an `OrderByComparator`. However, the underlying Service Builder-generated finder `AnnouncementsEntryPersistence.findByC_C_C_A` already provides an overload that takes one.

This PR:

1. Adds a new `getEntries(..., OrderByComparator<AnnouncementsEntry>)` overload to `AnnouncementsEntryLocalService` that delegates to the existing persistence finder. The original 6-arg `getEntries(...)` now routes through the new one passing `null` (which the persistence layer interprets as the default model `ORDER BY`), keeping full API backwards compatibility.
2. Regenerates the Service Builder kernel classes (`ant build-service-portlet-announcements`).
3. Updates `AnnouncementsAdminViewDisplayContext` to call the new overload and reuse the existing `getEntriesCount(...)` for the count, removing `_getDynamicQuery` plus the `DynamicQuery` / `RestrictionsFactoryUtil` imports.

Benefits:
- Query logic stays in the service layer where other callers can use it.
- No stringly-typed column restrictions (`"companyId"`, `"classNameId"`, `"alert"`, ...) in the display context.
- `getEntriesCount` stays on its proven `countByC_C_C_A` path; results and count can't drift.
- Fewer moving parts in the display context.

Note: source formatter wasn't run in this branch — if CI flags SF nits, a follow-up `LPD-86099 SF` commit covers it.

Feel free to reject, amend or cherry-pick — happy to adjust.